### PR TITLE
[Command] Add support for custom providers

### DIFF
--- a/docs/blacklist.md
+++ b/docs/blacklist.md
@@ -130,7 +130,17 @@ this library provides a number of command-line commands which you can use.
 To use these commands you need to install the [Symfony Console component][2].
 And register these commands for usage (see the Symfony manual for details).
 
+Each command expects a PSR-11 compatible container with the service-id
+as the provider name. At least "default" is expected to exists.
+
 ### Commands
+
+```php
+$providersContainer = ...; // \Psr\Container\ContainerInterface
+
+$application->add(new Rollerworks\Component\PasswordStrength\Command\BlacklistListCommand($providersContainer));
+```
+
 
 To add new passwords to the blacklist:
 
@@ -155,20 +165,25 @@ $ bin/console rollerworks-password:blacklist:update --file="/tmp/passwords-black
 To remove the database completely (**this will remove all the blacklisted passwords from your database**).
 
 ```bash
-$ app/console rollerworks-password:blacklist:purge
+$ bin/console rollerworks-password:blacklist:purge
 ```
 
 To export the database (this will display all the blacklisted passwords (one per line)) use.
 
 ```bash
-$ app/console rollerworks-password:blacklist:list
+$ bin/console rollerworks-password:blacklist:list
 ```
 
 You can also forward the result to a text file.
 
 ```bash
-$ app/console rollerworks-password:blacklist:list > /tmp/exported-blacklist.txt
+$ bin/console rollerworks-password:blacklist:list > /tmp/exported-blacklist.txt
 ```
+
+### Use a different provider
+
+To use a different provider then the de "default" use the `--provider` option, eg.
+`bin/console rollerworks-password:blacklist:purge --provider=sqlite`
 
 ## Existing blacklists
 

--- a/tests/Command/BlacklistCommandTest.php
+++ b/tests/Command/BlacklistCommandTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the RollerworksPasswordStrengthValidator package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\PasswordStrength\Tests\Command;
+
+use Rollerworks\Component\PasswordStrength\Command\BlacklistListCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class BlacklistCommandTest extends BlacklistCommandTestCase
+{
+    public function testValidatesProviderMustBeUpdatable()
+    {
+        $container = $this->createLoadersContainer([
+            'default' => self::$blackListProvider,
+            'second' => $this->createMockedProvider('nope'),
+        ]);
+
+        $application = new Application();
+        $application->add(new BlacklistListCommand($container));
+
+        $commandTester = new CommandTester($application->find('rollerworks-password:blacklist:list'));
+
+        $this->expectException('\RuntimeException');
+        $this->expectExceptionMessage('Blacklist provider "second" is not updatable.');
+
+        $commandTester->execute(['command' => $application->find('rollerworks-password:blacklist:list')->getName(), '--provider' => 'second']);
+    }
+
+    public function testSecondProviderIsUsed()
+    {
+        $blackListedWords = ['test', 'foobar', 'kaboom'];
+        foreach ($blackListedWords as $word) {
+            self::$blackListProvider->add($word);
+        }
+
+        $container = $this->createLoadersContainer([
+            'default' => $this->createMockedProvider('nope'),
+            'second' => self::$blackListProvider,
+        ]);
+
+        $application = new Application();
+        $application->add(new BlacklistListCommand($container));
+
+        $commandTester = new CommandTester($application->find('rollerworks-password:blacklist:list'));
+        $commandTester->execute(['command' => $application->find('rollerworks-password:blacklist:list')->getName(), '--provider' => 'second']);
+
+        $display = $commandTester->getDisplay(true);
+
+        // Words may be displayed in any order, so check each of them
+        foreach ($blackListedWords as $word) {
+            self::assertRegExp("/([\n]|^){$word}[\n]/s", $display);
+            self::$blackListProvider->add($word);
+        }
+    }
+}

--- a/tests/Command/BlacklistCommandTestCase.php
+++ b/tests/Command/BlacklistCommandTestCase.php
@@ -13,9 +13,12 @@ namespace Rollerworks\Component\PasswordStrength\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
 use Rollerworks\Component\PasswordStrength\Blacklist\SqliteProvider;
+use Rollerworks\Component\PasswordStrength\Tests\BlackListMockProviderTrait;
 
 abstract class BlacklistCommandTestCase extends TestCase
 {
+    use BlackListMockProviderTrait;
+
     protected static $dbFile;
     protected static $storage;
 

--- a/tests/Command/BlacklistDeleteCommandTest.php
+++ b/tests/Command/BlacklistDeleteCommandTest.php
@@ -171,7 +171,9 @@ class BlacklistDeleteCommandTest extends BlacklistCommandTestCase
     private function getCommand()
     {
         $application = new Application();
-        $application->add(new BlacklistDeleteCommand(self::$blackListProvider));
+        $application->add(new BlacklistDeleteCommand(
+            $this->createLoadersContainer(['default' => self::$blackListProvider])
+        ));
 
         return $application->find('rollerworks-password:blacklist:delete');
     }

--- a/tests/Command/BlacklistListCommandTest.php
+++ b/tests/Command/BlacklistListCommandTest.php
@@ -20,7 +20,7 @@ class BlacklistListCommandTest extends BlacklistCommandTestCase
     public function testList()
     {
         $application = new Application();
-        $command = new BlacklistListCommand(self::$blackListProvider);
+        $command = new BlacklistListCommand($this->createLoadersContainer(['default' => self::$blackListProvider]));
         $application->add($command);
 
         $command = $application->find('rollerworks-password:blacklist:list');

--- a/tests/Command/BlacklistPurgeCommandTest.php
+++ b/tests/Command/BlacklistPurgeCommandTest.php
@@ -96,7 +96,9 @@ class BlacklistPurgeCommandTest extends BlacklistCommandTestCase
     private function getCommand()
     {
         $application = new Application();
-        $application->add(new BlacklistPurgeCommand(self::$blackListProvider));
+        $application->add(
+            new BlacklistPurgeCommand($this->createLoadersContainer(['default' => self::$blackListProvider]))
+        );
 
         return $application->find('rollerworks-password:blacklist:purge');
     }

--- a/tests/Command/BlacklistUpdateCommandTest.php
+++ b/tests/Command/BlacklistUpdateCommandTest.php
@@ -166,7 +166,9 @@ class BlacklistUpdateCommandTest extends BlacklistCommandTestCase
     private function getCommand()
     {
         $application = new Application();
-        $application->add(new BlacklistUpdateCommand(self::$blackListProvider));
+        $application->add(
+            new BlacklistUpdateCommand($this->createLoadersContainer(['default' => self::$blackListProvider]))
+        );
 
         return $application->find('rollerworks-password:blacklist:update');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

Added the `--provider` option to all commands, this allow to use a different provider then the default. This is the final change that closes https://github.com/rollerworks/PasswordStrengthBundle/issues/9 