### PR TITLE
Fix translation placeholder mistakes

### DIFF
--- a/src/Resources/translations/validators.bg.xlf
+++ b/src/Resources/translations/validators.bg.xlf
@@ -24,7 +24,7 @@
             </trans-unit>
             <trans-unit id="6">
                 <source>password_too_weak</source>
-                <target>Паролата трябва да е поне на ниво "{{min_strength}}", текущото ниво е "{{current_strength}}", опитайте това: {{strength_tips}}.</target>
+                <target>Паролата трябва да е поне на ниво "{{ min_strength }}", текущото ниво е "{{ current_strength }}", опитайте това: {{ strength_tips }}.</target>
             </trans-unit>
 
             <!-- Strength levels -->

--- a/src/Resources/translations/validators.pt_BR.xlf
+++ b/src/Resources/translations/validators.pt_BR.xlf
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="1">
                 <source>Your password must be at least {{length}} characters long.</source>
-                <target>A senha deve ter pelo menos {{comprimento}} caracteres de comprimento.</target>
+                <target>A senha deve ter pelo menos {{length}} caracteres de comprimento.</target>
             </trans-unit>
             <trans-unit id="2">
                 <source>Your password must include at least one letter.</source>

--- a/src/Resources/translations/validators.ru.xlf
+++ b/src/Resources/translations/validators.ru.xlf
@@ -24,7 +24,7 @@
             </trans-unit>
             <trans-unit id="6">
                 <source>password_too_weak</source>
-                <target>Пароль должен быть как минимум "{{ min_strength }}" уровня сложности, текущий уровень сложности "{{ current_strength }}", обратите внимание на эти советы: {{strong_tips}}.</target>
+                <target>Пароль должен быть как минимум "{{ min_strength }}" уровня сложности, текущий уровень сложности "{{ current_strength }}", обратите внимание на эти советы: {{ strong_tips }}.</target>
             </trans-unit>
 
             <!-- Strength levels -->


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT

The last translations I contributed from our contractor were containing a few mistakes regarding placeholders, altering them compared to the original ones (and so failing to be replaced). This fixes them.