### PR TITLE
Add Annotation to P0wnedPassword

### DIFF
--- a/src/Validator/Constraints/P0wnedPassword.php
+++ b/src/Validator/Constraints/P0wnedPassword.php
@@ -13,6 +13,9 @@ namespace Rollerworks\Component\PasswordStrength\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+/**
+ * @Annotation
+ */
 class P0wnedPassword extends Constraint
 {
     public $message = 'This password was found in a database of compromised passwords. It has been used {{ used }} times. For security purposes you must use something else.';


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Without this change i become this error:

The class "Rollerworks\Component\PasswordStrength\Validator\Constraints\P0wnedPassword" is not annotated with @Annotation. Are you sure this class can be used as annotation? If so, then you need to add @Annotation to the _class_ doc comment of "Rollerworks\Component\PasswordStrength\Validator\Constraints\P0wnedPassword".
