### PR TITLE
Add @Ignore annotations for incomplete translation keys

### DIFF
--- a/src/Validator/Constraints/PasswordStrengthValidator.php
+++ b/src/Validator/Constraints/PasswordStrengthValidator.php
@@ -107,8 +107,8 @@ class PasswordStrengthValidator extends ConstraintValidator
         if ($passwordStrength < $constraint->minStrength) {
             $parameters = [
                 '{{ length }}' => $constraint->minLength,
-                '{{ min_strength }}' => $this->translator->trans('rollerworks_password.strength_level.'.self::$levelToLabel[$constraint->minStrength], [], 'validators'),
-                '{{ current_strength }}' => $this->translator->trans('rollerworks_password.strength_level.'.self::$levelToLabel[$passwordStrength], [], 'validators'),
+                '{{ min_strength }}' => $this->translator->trans(/** @Ignore */'rollerworks_password.strength_level.'.self::$levelToLabel[$constraint->minStrength], [], 'validators'),
+                '{{ current_strength }}' => $this->translator->trans(/** @Ignore */'rollerworks_password.strength_level.'.self::$levelToLabel[$passwordStrength], [], 'validators'),
                 '{{ strength_tips }}' => implode(', ', array_map([$this, 'translateTips'], $tips)),
             ];
 
@@ -123,7 +123,7 @@ class PasswordStrengthValidator extends ConstraintValidator
      */
     public function translateTips($tip)
     {
-        return $this->translator->trans('rollerworks_password.tip.'.$tip, [], 'validators');
+        return $this->translator->trans(/** @Ignore */'rollerworks_password.tip.'.$tip, [], 'validators');
     }
 
     private function calculateStrength($password, &$tips)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT

As some translation keys are dynamically build, they now are marked as `missing` when running `bin/console debug:translation en --only-missing` for example. Adding the `/** @Ignore */` suppresses the marking.
