### PR TITLE
Update strength-validation.md

### DIFF
--- a/docs/strength-validation.md
+++ b/docs/strength-validation.md
@@ -23,7 +23,7 @@ The strengths are listed as follows:
 
 *  1: Very Weak (any character)
 *  2: Weak (at least one lower and capital)
-*  3: Medium (at least one lower and capital and number)
+*  3: Medium (at least one lower or capital and number)
 *  4: Strong (at least one lower and capital and number) (recommended for most usages)
 *  5: Very Strong (recommended for admin or finance related services)
 


### PR DESCRIPTION
I found out that medium seems to be any character (min or cap) and a number vs strength 4 is written properly

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Documentation was wrong about point #3, it was the same thing as strength #4 in the description.
