### PR TITLE
Fix regex for specials characters

### DIFF
--- a/src/Validator/Constraints/PasswordRequirementsValidator.php
+++ b/src/Validator/Constraints/PasswordRequirementsValidator.php
@@ -56,7 +56,7 @@ class PasswordRequirementsValidator extends ConstraintValidator
                 ->addViolation();
         }
 
-        if ($constraint->requireSpecialCharacter && !preg_match('/[^p{Ll}\p{Lu}\pL\pN]/u', $value)) {
+        if ($constraint->requireSpecialCharacter && !preg_match('/[^\p{Ll}\p{Lu}\pL\pN]/u', $value)) {
             $this->context->buildViolation($constraint->missingSpecialCharacterMessage)
                 ->setInvalidValue($value)
                 ->addViolation();

--- a/tests/Validator/PasswordRequirementsValidatorTest.php
+++ b/tests/Validator/PasswordRequirementsValidatorTest.php
@@ -116,6 +116,7 @@ class PasswordRequirementsValidatorTest extends ConstraintValidatorTestCase
             ['®', new PasswordRequirements(['minLength' => 1, 'requireLetters' => false, 'requireSpecialCharacter' => true])],
             ['»', new PasswordRequirements(['minLength' => 1, 'requireLetters' => false, 'requireSpecialCharacter' => true])],
             ['<>', new PasswordRequirements(['minLength' => 1, 'requireLetters' => false, 'requireSpecialCharacter' => true])],
+            ['{}', new PasswordRequirements(['minLength' => 1, 'requireLetters' => false, 'requireSpecialCharacter' => true])],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

Fixed regex when use specials characters like '{}'.
