### PR TITLE
Deprecate PwnedPassword in favor of Symfony one

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ But building your own is also possible.
 __Documentation on this is currently missing,
 see current providers for more information.__
 
-### PwnedPassword
+### PwnedPassword (deprecated)
+
+⚠️ **This validator is deprecated in favor of the Symfony [NotCompromisedPassword](https://symfony.com/doc/current/reference/constraints/NotCompromisedPassword.html)
+validator.**
 
 Validates that the requested password was not found in a trove of compromised passwords found at <https://haveibeenpwned.com/>.
 

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "php": ">=7.1",
         "psr/container": "^1.0",
         "psr/log": "^1.0",
+        "symfony/deprecation-contracts": "^2.4",
         "symfony/polyfill-mbstring": "^1.5.0",
         "symfony/translation": "^3.4.22 || ^4.0 || ^5.0",
         "symfony/validator": "^3.4.22 || ^4.0 || ^5.0"
@@ -43,7 +44,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-main": "1.4-dev"
         }
     },
     "config": {

--- a/src/P0wnedPassword/Request/Client.php
+++ b/src/P0wnedPassword/Request/Client.php
@@ -17,6 +17,9 @@ use Http\Client\Exception\HttpException;
 use Http\Client\HttpClient;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @internal
+ */
 class Client
 {
     /** @var HttpClient */

--- a/src/P0wnedPassword/Request/Result.php
+++ b/src/P0wnedPassword/Request/Result.php
@@ -11,6 +11,9 @@
 
 namespace Rollerworks\Component\PasswordStrength\P0wnedPassword\Request;
 
+/**
+ * @internal
+ */
 class Result
 {
     /**

--- a/src/Validator/Constraints/P0wnedPassword.php
+++ b/src/Validator/Constraints/P0wnedPassword.php
@@ -13,8 +13,12 @@ namespace Rollerworks\Component\PasswordStrength\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+trigger_deprecation('rollerworks/password-strength-validator', '1.4', 'The P0wnedPassword validator is deprecated and will be removed in the next major version. Use the NotCompromisedPassword validator from the symfony/validator package instead.', P0wnedPassword::class);
+
 /**
  * @Annotation
+ *
+ * @deprecated since rollerworks/password-strength-validator 1.4 The P0wnedPassword validator is deprecated and will be removed in the next major version. Use the NotCompromisedPassword validator from the symfony/validator package instead.
  */
 class P0wnedPassword extends Constraint
 {

--- a/tests/Validator/P0wnedPasswordValidatorTest.php
+++ b/tests/Validator/P0wnedPasswordValidatorTest.php
@@ -19,6 +19,9 @@ use Rollerworks\Component\PasswordStrength\Validator\Constraints\P0wnedPasswordV
 use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
+/**
+ * @group legacy
+ */
 class P0wnedPasswordValidatorTest extends ConstraintValidatorTestCase
 {
     use SetUpTearDownTrait;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 
| License       | MIT

Symfony since v4.4 Symfony provides build-in supports for this validator.
