### PR TITLE
Remove support for PHP 7.1 and fix deprecations

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,17 @@
 | Q             | A
 | ------------- | ---
+| Branch?       | main for features / 1.4 bug/translation fixes <!-- see below -->
 | Bug fix?      | yes/no
 | New feature?  | yes/no
 | BC breaks?    | yes/no
 | Deprecations? | yes/no
-| Tests pass?   | yes/no
-| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
+| Fixed tickets | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
 | License       | MIT
 
 <!--
 - Please fill in this template according to the PR you're about to submit.
   Provide additional information in your description, not the questioner table.
 - Replace this comment by a description of what your PR is solving.
+- Bug fixes must be submitted against the lowest maintained branch where they apply
+  (lowest branches are regularly merged to upper ones so they get the fixes too.)
 -->

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,15 +15,15 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - PHP_VERSION: '7.1'
-                      SYMFONY_REQUIRE: '^3.4'
-                    - PHP_VERSION: '7.2'
+                    - PHP_VERSION: '7.3'
                       SYMFONY_REQUIRE: '^4.4'
                     - PHP_VERSION: '7.3'
                       SYMFONY_REQUIRE: '^5.0'
                     - PHP_VERSION: '7.4'
                       SYMFONY_REQUIRE: '^5.2'
                     - PHP_VERSION: '8.0'
+                    - PHP_VERSION: '8.0'
+                      SYMFONY_REQUIRE: '^6.0'
 
         steps:
             # —— Setup Github actions 🐙 —————————————————————————————————————————————
@@ -49,8 +49,6 @@ jobs:
                 env:
                     SYMFONY_REQUIRE: ${{ matrix.SYMFONY_REQUIRE }}
                     SYMFONY_PHPUNIT_DISABLE_RESULT_CACHE: 1
-                    SYMFONY_PHPUNIT_REMOVE: "symfony/yaml"
-                    SYMFONY_PHPUNIT_VERSION: '7.5.6'
                 run: |
                     git config --global author.name Sebastiaan Stok
                     git config --global author.email s.stok@rollerscapes.net

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install:
 	composer install --no-progress --no-interaction --no-suggest --optimize-autoloader --prefer-dist --ansi
 
 test:
-	./vendor/bin/simple-phpunit --verbose
+	./vendor/bin/phpunit --verbose
 
 # Linting tools
 security-check: ensure

--- a/composer.json
+++ b/composer.json
@@ -15,21 +15,23 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
-        "psr/container": "^1.0",
+        "php": ">=7.3",
+        "psr/container": "^1.0 || ^2.0",
         "psr/log": "^1.0",
         "symfony/deprecation-contracts": "^2.4",
         "symfony/polyfill-mbstring": "^1.5.0",
-        "symfony/translation": "^3.4.22 || ^4.0 || ^5.0",
-        "symfony/validator": "^3.4.22 || ^4.0 || ^5.0"
+        "symfony/translation": "^4.4 || ^5.0 || ^6.0",
+        "symfony/validator": "^4.4 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.4",
         "php-http/httplug": "^1.1",
         "phpspec/prophecy": "^1.10.3",
-        "symfony/config": "^3.4.22 || ^4.0 || ^5.0",
-        "symfony/console": "^3.4.22 || ^4.0 || ^5.0",
-        "symfony/phpunit-bridge": "^4.4 || ^5.0"
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.5",
+        "symfony/config": "^4.4 || ^5.0 || ^6.0",
+        "symfony/console": "^4.4 || ^5.0 || ^6.0",
+        "symfony/phpunit-bridge": "^5.3 || ^6.0"
     },
     "autoload": {
         "psr-4": {
@@ -44,7 +46,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.4-dev"
+            "dev-main": "1.5-dev"
         }
     },
     "config": {
@@ -52,5 +54,7 @@
             "*": "dist"
         },
         "sort-packages": true
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.6/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
@@ -16,6 +16,8 @@
         <ini name="intl.error_level" value="0"/>
         <ini name="memory_limit" value="-1"/>
         <ini name="default_charset" value="UTF-8"/>
+
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
     </php>
 
     <testsuites>
@@ -24,13 +26,17 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
-            <directory>./src</directory>
-            <exclude>
-                <directory>./vendor/</directory>
-                <directory>./tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+    <coverage>
+        <include>
+            <directory>src/</directory>
+        </include>
+        <exclude>
+            <directory>vendor/</directory>
+            <directory>tests/</directory>
+        </exclude>
+    </coverage>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Validator/Constraints/PasswordStrengthValidator.php
+++ b/src/Validator/Constraints/PasswordStrengthValidator.php
@@ -112,8 +112,8 @@ class PasswordStrengthValidator extends ConstraintValidator
         if ($passwordStrength < $constraint->minStrength) {
             $parameters = [
                 '{{ length }}' => $constraint->minLength,
-                '{{ min_strength }}' => $this->translator->trans(/* @Ignore */'rollerworks_password.strength_level.'.self::$levelToLabel[$constraint->minStrength], [], 'validators'),
-                '{{ current_strength }}' => $this->translator->trans(/* @Ignore */'rollerworks_password.strength_level.'.self::$levelToLabel[$passwordStrength], [], 'validators'),
+                '{{ min_strength }}' => $this->translator->trans(/* @Ignore */ 'rollerworks_password.strength_level.'.self::$levelToLabel[$constraint->minStrength], [], 'validators'),
+                '{{ current_strength }}' => $this->translator->trans(/* @Ignore */ 'rollerworks_password.strength_level.'.self::$levelToLabel[$passwordStrength], [], 'validators'),
                 '{{ strength_tips }}' => implode(', ', array_map([$this, 'translateTips'], $tips)),
             ];
 
@@ -128,7 +128,7 @@ class PasswordStrengthValidator extends ConstraintValidator
      */
     public function translateTips($tip)
     {
-        return $this->translator->trans(/* @Ignore */'rollerworks_password.tip.'.$tip, [], 'validators');
+        return $this->translator->trans(/* @Ignore */ 'rollerworks_password.tip.'.$tip, [], 'validators');
     }
 
     private function calculateStrength($password, &$tips)

--- a/tests/BlackListMockProviderTrait.php
+++ b/tests/BlackListMockProviderTrait.php
@@ -12,17 +12,14 @@
 namespace Rollerworks\Component\PasswordStrength\Tests;
 
 use Prophecy\Argument;
-use Prophecy\Prophecy\ObjectProphecy;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 use Rollerworks\Component\PasswordStrength\Blacklist\BlacklistProviderInterface;
 
-/**
- * Trait BlackListMockProviderTrait.
- *
- * @method ObjectProphecy prophesize($class)
- */
 trait BlackListMockProviderTrait
 {
+    use ProphecyTrait;
+
     protected function createMockedProvider($blacklisted)
     {
         $mockProvider = $this->prophesize(BlacklistProviderInterface::class);

--- a/tests/Blacklist/SqliteProviderTest.php
+++ b/tests/Blacklist/SqliteProviderTest.php
@@ -13,12 +13,9 @@ namespace Rollerworks\Component\PasswordStrength\Tests\Blacklist;
 
 use PHPUnit\Framework\TestCase;
 use Rollerworks\Component\PasswordStrength\Blacklist\SqliteProvider;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 class SqliteProviderTest extends TestCase
 {
-    use SetUpTearDownTrait;
-
     /**
      * @var string
      */
@@ -29,7 +26,7 @@ class SqliteProviderTest extends TestCase
      */
     protected static $provider;
 
-    public static function doSetUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!class_exists('SQLite3') && (!class_exists('PDO') || !in_array('sqlite', \PDO::getAvailableDrivers(), true))) {
             self::markTestSkipped('This test requires SQLite support in your environment');
@@ -43,7 +40,7 @@ class SqliteProviderTest extends TestCase
         self::$provider = new SqliteProvider('sqlite:'.self::$dbFile);
     }
 
-    public static function doTearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         @unlink(self::$dbFile);
     }
@@ -87,7 +84,7 @@ class SqliteProviderTest extends TestCase
         self::assertTrue(self::$provider->isBlacklisted('test'));
     }
 
-    protected function doSetUp()
+    protected function setUp(): void
     {
         if (!class_exists('SQLite3') && (!class_exists('PDO') || !in_array('sqlite', \PDO::getAvailableDrivers(), true))) {
             $this->markTestSkipped('This test requires SQLite support in your environment');

--- a/tests/Command/BlacklistCommandTest.php
+++ b/tests/Command/BlacklistCommandTest.php
@@ -57,7 +57,7 @@ class BlacklistCommandTest extends BlacklistCommandTestCase
 
         // Words may be displayed in any order, so check each of them
         foreach ($blackListedWords as $word) {
-            self::assertRegExp("/([\n]|^){$word}[\n]/s", $display);
+            self::assertMatchesRegularExpression("/([\n]|^){$word}[\n]/s", $display);
             self::$blackListProvider->add($word);
         }
     }

--- a/tests/Command/BlacklistCommandTestCase.php
+++ b/tests/Command/BlacklistCommandTestCase.php
@@ -14,12 +14,10 @@ namespace Rollerworks\Component\PasswordStrength\Tests\Command;
 use PHPUnit\Framework\TestCase;
 use Rollerworks\Component\PasswordStrength\Blacklist\SqliteProvider;
 use Rollerworks\Component\PasswordStrength\Tests\BlackListMockProviderTrait;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 abstract class BlacklistCommandTestCase extends TestCase
 {
     use BlackListMockProviderTrait;
-    use SetUpTearDownTrait;
 
     protected static $dbFile;
     protected static $storage;
@@ -29,7 +27,7 @@ abstract class BlacklistCommandTestCase extends TestCase
      */
     protected static $blackListProvider;
 
-    public static function doSetUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!class_exists('SQLite3') && (!class_exists('PDO') || !in_array('sqlite', \PDO::getAvailableDrivers(), true))) {
             self::markTestSkipped('This test requires SQLite support in your environment');
@@ -43,12 +41,12 @@ abstract class BlacklistCommandTestCase extends TestCase
         self::$blackListProvider = new SqliteProvider('sqlite:'.self::$dbFile);
     }
 
-    public static function doTearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         @unlink(self::$dbFile);
     }
 
-    protected function doSetUp()
+    protected function setUp(): void
     {
         self::$blackListProvider->purge();
     }

--- a/tests/Command/BlacklistDeleteCommandTest.php
+++ b/tests/Command/BlacklistDeleteCommandTest.php
@@ -33,7 +33,7 @@ class BlacklistDeleteCommandTest extends BlacklistCommandTestCase
         self::assertFalse(self::$blackListProvider->isBlacklisted('test'));
         self::assertTrue(self::$blackListProvider->isBlacklisted('foobar'));
 
-        self::assertRegExp('/Successfully removed 1 password\(s\) from your blacklist database/', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('/Successfully removed 1 password\(s\) from your blacklist database/', $commandTester->getDisplay());
     }
 
     public function testDeleteNoneExistingWord()
@@ -46,7 +46,7 @@ class BlacklistDeleteCommandTest extends BlacklistCommandTestCase
         $commandTester->execute(['command' => $command->getName(), 'passwords' => 'test']);
 
         self::assertFalse(self::$blackListProvider->isBlacklisted('test'));
-        self::assertRegExp('/Successfully removed 0 password\(s\) from your blacklist database/', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('/Successfully removed 0 password\(s\) from your blacklist database/', $commandTester->getDisplay());
     }
 
     public function testDeleteTwoWords()
@@ -64,7 +64,7 @@ class BlacklistDeleteCommandTest extends BlacklistCommandTestCase
         self::assertFalse(self::$blackListProvider->isBlacklisted('foobar'));
         self::assertTrue(self::$blackListProvider->isBlacklisted('kaboom'));
 
-        self::assertRegExp('/Successfully removed 2 password\(s\) from your blacklist database/', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('/Successfully removed 2 password\(s\) from your blacklist database/', $commandTester->getDisplay());
     }
 
     public function testNoInput()
@@ -74,8 +74,8 @@ class BlacklistDeleteCommandTest extends BlacklistCommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName()]);
 
-        self::assertNotRegExp('/Successfully removed \d+ password\(s\) from your blacklist database/', $commandTester->getDisplay());
-        self::assertRegExp('/No passwords or file-option given/', $commandTester->getDisplay());
+        self::assertDoesNotMatchRegularExpression('/Successfully removed \d+ password\(s\) from your blacklist database/', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('/No passwords or file-option given/', $commandTester->getDisplay());
     }
 
     public function testReadFromFile()
@@ -89,7 +89,7 @@ class BlacklistDeleteCommandTest extends BlacklistCommandTestCase
         $commandTester = new CommandTester($command);
 
         $commandTester->execute(['command' => $command->getName(), '--file' => __DIR__.'/../fixtures/passwords-list1.txt']);
-        self::assertRegExp('/Successfully removed 2 password\(s\) from your blacklist database/', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('/Successfully removed 2 password\(s\) from your blacklist database/', $commandTester->getDisplay());
 
         self::assertFalse(self::$blackListProvider->isBlacklisted('test'));
         self::assertFalse(self::$blackListProvider->isBlacklisted('foobar'));
@@ -107,14 +107,14 @@ class BlacklistDeleteCommandTest extends BlacklistCommandTestCase
         $commandTester = new CommandTester($command);
 
         $commandTester->execute(['command' => $command->getName(), '--file' => __DIR__.'/../fixtures/passwords-list1.txt']);
-        self::assertRegExp('/Successfully removed 2 password\(s\) from your blacklist database/', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('/Successfully removed 2 password\(s\) from your blacklist database/', $commandTester->getDisplay());
 
         self::assertFalse(self::$blackListProvider->isBlacklisted('test'));
         self::assertFalse(self::$blackListProvider->isBlacklisted('foobar'));
         self::assertTrue(self::$blackListProvider->isBlacklisted('kaboom'));
 
         $commandTester->execute(['command' => $command->getName(), '--file' => __DIR__.'/../fixtures/passwords-list1.txt']);
-        self::assertRegExp('/Successfully removed 0 password\(s\) from your blacklist database/', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('/Successfully removed 0 password\(s\) from your blacklist database/', $commandTester->getDisplay());
     }
 
     public function testImportFromRelFile()
@@ -131,7 +131,7 @@ class BlacklistDeleteCommandTest extends BlacklistCommandTestCase
         chdir(__DIR__);
 
         $commandTester->execute(['command' => $command->getName(), '--file' => '../fixtures/passwords-list1.txt']);
-        self::assertRegExp('/Successfully removed 2 password\(s\) from your blacklist database/', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('/Successfully removed 2 password\(s\) from your blacklist database/', $commandTester->getDisplay());
 
         self::assertFalse(self::$blackListProvider->isBlacklisted('test'));
         self::assertFalse(self::$blackListProvider->isBlacklisted('foobar'));
@@ -150,7 +150,7 @@ class BlacklistDeleteCommandTest extends BlacklistCommandTestCase
             ['command' => $command->getName(), '--file' => '../fixtures/unknown.txt']
         );
 
-        self::assertRegExp('#Unable to read passwords list. No such file: \.\./fixtures/unknown\.txt#', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('#Unable to read passwords list. No such file: \.\./fixtures/unknown\.txt#', $commandTester->getDisplay());
     }
 
     public function testImportFromEmptyFile()
@@ -165,7 +165,7 @@ class BlacklistDeleteCommandTest extends BlacklistCommandTestCase
             ['command' => $command->getName(), '--file' => __DIR__.'/../fixtures/passwords-list2.txt']
         );
 
-        self::assertRegExp('/Passwords list seems empty, are you sure this is the correct file\?/', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('/Passwords list seems empty, are you sure this is the correct file\?/', $commandTester->getDisplay());
     }
 
     private function getCommand()

--- a/tests/Command/BlacklistListCommandTest.php
+++ b/tests/Command/BlacklistListCommandTest.php
@@ -44,7 +44,7 @@ class BlacklistListCommandTest extends BlacklistCommandTestCase
 
         // Words may be displayed in any order, so check each of them
         foreach ($blackListedWords as $word) {
-            self::assertRegExp("/([\n]|^){$word}[\n]/s", $display);
+            self::assertMatchesRegularExpression("/([\n]|^){$word}[\n]/s", $display);
             self::$blackListProvider->add($word);
         }
     }

--- a/tests/Command/BlacklistPurgeCommandTest.php
+++ b/tests/Command/BlacklistPurgeCommandTest.php
@@ -34,10 +34,10 @@ class BlacklistPurgeCommandTest extends BlacklistCommandTestCase
         $commandTester->execute(['command' => $command->getName()], ['interactive' => true]);
 
         $display = $commandTester->getDisplay(true);
-        self::assertRegExp('/This will remove all the passwords from your blacklist./', $display);
-        self::assertRegExp('/Are you sure you want to purge the blacklist\?/', $display);
+        self::assertMatchesRegularExpression('/This will remove all the passwords from your blacklist./', $display);
+        self::assertMatchesRegularExpression('/Are you sure you want to purge the blacklist\?/', $display);
 
-        self::assertNotRegExp('/Successfully removed all passwords from your blacklist\./', $commandTester->getDisplay(true));
+        self::assertDoesNotMatchRegularExpression('/Successfully removed all passwords from your blacklist\./', $commandTester->getDisplay(true));
 
         self::assertTrue(self::$blackListProvider->isBlacklisted('test'));
         self::assertTrue(self::$blackListProvider->isBlacklisted('foobar'));
@@ -61,10 +61,10 @@ class BlacklistPurgeCommandTest extends BlacklistCommandTestCase
         $commandTester->execute(['command' => $command->getName()]);
 
         $display = $commandTester->getDisplay(true);
-        self::assertRegExp('/This will remove all the passwords from your blacklist\./', $display);
-        self::assertRegExp('/Are you sure you want to purge the blacklist\?/', $display);
+        self::assertMatchesRegularExpression('/This will remove all the passwords from your blacklist\./', $display);
+        self::assertMatchesRegularExpression('/Are you sure you want to purge the blacklist\?/', $display);
 
-        self::assertRegExp('/Successfully removed all passwords from your blacklist\./', $commandTester->getDisplay(true));
+        self::assertMatchesRegularExpression('/Successfully removed all passwords from your blacklist\./', $commandTester->getDisplay(true));
 
         self::assertFalse(self::$blackListProvider->isBlacklisted('test'));
         self::assertFalse(self::$blackListProvider->isBlacklisted('foobar'));
@@ -86,7 +86,7 @@ class BlacklistPurgeCommandTest extends BlacklistCommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName(), '--no-ask' => null]);
 
-        self::assertRegExp('/Successfully removed all passwords from your blacklist\./', $commandTester->getDisplay(true));
+        self::assertMatchesRegularExpression('/Successfully removed all passwords from your blacklist\./', $commandTester->getDisplay(true));
 
         self::assertFalse(self::$blackListProvider->isBlacklisted('test'));
         self::assertFalse(self::$blackListProvider->isBlacklisted('foobar'));

--- a/tests/Command/BlacklistUpdateCommandTest.php
+++ b/tests/Command/BlacklistUpdateCommandTest.php
@@ -27,7 +27,7 @@ class BlacklistUpdateCommandTest extends BlacklistCommandTestCase
         $commandTester->execute(['command' => $command->getName(), 'passwords' => 'test']);
 
         self::assertTrue(self::$blackListProvider->isBlacklisted('test'));
-        self::assertRegExp('/Successfully added 1 password\(s\) to your blacklist database/', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('/Successfully added 1 password\(s\) to your blacklist database/', $commandTester->getDisplay());
     }
 
     public function testAddExistingWord()
@@ -40,13 +40,13 @@ class BlacklistUpdateCommandTest extends BlacklistCommandTestCase
         $commandTester->execute(['command' => $command->getName(), 'passwords' => 'test']);
 
         self::assertTrue(self::$blackListProvider->isBlacklisted('test'));
-        self::assertRegExp('/Successfully added 1 password\(s\) to your blacklist database/', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('/Successfully added 1 password\(s\) to your blacklist database/', $commandTester->getDisplay());
 
         self::assertTrue(self::$blackListProvider->isBlacklisted('test'));
         $commandTester->execute(['command' => $command->getName(), 'passwords' => 'test']);
 
         self::assertTrue(self::$blackListProvider->isBlacklisted('test'));
-        self::assertRegExp('/Successfully added 0 password\(s\) to your blacklist database/', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('/Successfully added 0 password\(s\) to your blacklist database/', $commandTester->getDisplay());
     }
 
     public function testAddTwoWords()
@@ -61,7 +61,7 @@ class BlacklistUpdateCommandTest extends BlacklistCommandTestCase
 
         self::assertTrue(self::$blackListProvider->isBlacklisted('test'));
         self::assertTrue(self::$blackListProvider->isBlacklisted('foobar'));
-        self::assertRegExp('/Successfully added 2 password\(s\) to your blacklist database/', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('/Successfully added 2 password\(s\) to your blacklist database/', $commandTester->getDisplay());
     }
 
     public function testNoInput()
@@ -71,8 +71,8 @@ class BlacklistUpdateCommandTest extends BlacklistCommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName()]);
 
-        self::assertNotRegExp('/Successfully added \d+ password\(s\) to your blacklist database/', $commandTester->getDisplay());
-        self::assertRegExp('/No passwords or file-option given/', $commandTester->getDisplay());
+        self::assertDoesNotMatchRegularExpression('/Successfully added \d+ password\(s\) to your blacklist database/', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('/No passwords or file-option given/', $commandTester->getDisplay());
     }
 
     public function testImportFromFile()
@@ -87,7 +87,7 @@ class BlacklistUpdateCommandTest extends BlacklistCommandTestCase
 
         self::assertTrue(self::$blackListProvider->isBlacklisted('test'));
         self::assertTrue(self::$blackListProvider->isBlacklisted('foobar'));
-        self::assertRegExp('/Successfully added 2 password\(s\) to your blacklist database/', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('/Successfully added 2 password\(s\) to your blacklist database/', $commandTester->getDisplay());
     }
 
     public function testImportExistingFromFile()
@@ -102,7 +102,7 @@ class BlacklistUpdateCommandTest extends BlacklistCommandTestCase
 
         self::assertTrue(self::$blackListProvider->isBlacklisted('test'));
         self::assertTrue(self::$blackListProvider->isBlacklisted('foobar'));
-        self::assertRegExp('/Successfully added 2 password\(s\) to your blacklist database/', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('/Successfully added 2 password\(s\) to your blacklist database/', $commandTester->getDisplay());
 
         self::assertTrue(self::$blackListProvider->isBlacklisted('test'));
         self::assertTrue(self::$blackListProvider->isBlacklisted('foobar'));
@@ -110,7 +110,7 @@ class BlacklistUpdateCommandTest extends BlacklistCommandTestCase
 
         self::assertTrue(self::$blackListProvider->isBlacklisted('test'));
         self::assertTrue(self::$blackListProvider->isBlacklisted('foobar'));
-        self::assertRegExp('/Successfully added 0 password\(s\) to your blacklist database/', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('/Successfully added 0 password\(s\) to your blacklist database/', $commandTester->getDisplay());
     }
 
     public function testImportFromRelFile()
@@ -128,7 +128,7 @@ class BlacklistUpdateCommandTest extends BlacklistCommandTestCase
             ['command' => $command->getName(), '--file' => '../fixtures/passwords-list1.txt']
         );
 
-        self::assertRegExp('/Successfully added 2 password\(s\) to your blacklist database/', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('/Successfully added 2 password\(s\) to your blacklist database/', $commandTester->getDisplay());
         self::assertTrue(self::$blackListProvider->isBlacklisted('test'));
         self::assertTrue(self::$blackListProvider->isBlacklisted('foobar'));
     }
@@ -145,7 +145,7 @@ class BlacklistUpdateCommandTest extends BlacklistCommandTestCase
             ['command' => $command->getName(), '--file' => '../fixtures/unknown.txt']
         );
 
-        self::assertRegExp('#Unable to read passwords list. No such file: \.\./fixtures/unknown\.txt#', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('#Unable to read passwords list. No such file: \.\./fixtures/unknown\.txt#', $commandTester->getDisplay());
     }
 
     public function testImportFromEmptyFile()
@@ -160,7 +160,7 @@ class BlacklistUpdateCommandTest extends BlacklistCommandTestCase
             ['command' => $command->getName(), '--file' => __DIR__.'/../fixtures/passwords-list2.txt']
         );
 
-        self::assertRegExp('/Passwords list seems empty, are you sure this is the correct file\?/', $commandTester->getDisplay());
+        self::assertMatchesRegularExpression('/Passwords list seems empty, are you sure this is the correct file\?/', $commandTester->getDisplay());
     }
 
     private function getCommand()

--- a/tests/P0wnedPassword/Request/ClientTest.php
+++ b/tests/P0wnedPassword/Request/ClientTest.php
@@ -19,12 +19,9 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Rollerworks\Component\PasswordStrength\P0wnedPassword\Request\Client;
 use Rollerworks\Component\PasswordStrength\P0wnedPassword\Request\Result;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 class ClientTest extends TestCase
 {
-    use SetUpTearDownTrait;
-
     /** @var HttpClient|MockObject */
     private $client;
 
@@ -59,7 +56,7 @@ class ClientTest extends TestCase
 0C341F894BD4EE961AE874ACD3BC8157825:4
 ';
 
-    public function doSetUp()
+    protected function setUp(): void
     {
         $this->client = $this->createMock(HttpClient::class);
         $this->checker = new Client($this->client, new NullLogger());

--- a/tests/Validator/BlacklistValidationTest.php
+++ b/tests/Validator/BlacklistValidationTest.php
@@ -23,26 +23,6 @@ class BlacklistValidationTest extends ConstraintValidatorTestCase
 {
     use BlackListMockProviderTrait;
 
-    public function getMock($originalClassName, $methods = [], array $arguments = [], $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $cloneArguments = false, $callOriginalMethods = false, $proxyTarget = null)
-    {
-        if (func_num_args() === 1 && preg_match('/^Symfony\\\\Component\\\\([a-z]+\\\\)+[a-z]+Interface$/i', $originalClassName)) {
-            return $this->getMockBuilder($originalClassName)->getMock();
-        }
-
-        return parent::getMock(
-            $originalClassName,
-            $methods,
-            $arguments,
-            $mockClassName,
-            $callOriginalConstructor,
-            $callOriginalClone,
-            $callAutoload,
-            $cloneArguments,
-            $callOriginalMethods,
-            $proxyTarget
-        );
-    }
-
     protected function createValidator()
     {
         $provider = new ArrayProvider(['test', 'foobar']);

--- a/tests/Validator/P0wnedPasswordValidatorTest.php
+++ b/tests/Validator/P0wnedPasswordValidatorTest.php
@@ -16,7 +16,6 @@ use Rollerworks\Component\PasswordStrength\P0wnedPassword\Request\Client;
 use Rollerworks\Component\PasswordStrength\P0wnedPassword\Request\Result;
 use Rollerworks\Component\PasswordStrength\Validator\Constraints\P0wnedPassword;
 use Rollerworks\Component\PasswordStrength\Validator\Constraints\P0wnedPasswordValidator;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 /**
@@ -24,15 +23,13 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
  */
 class P0wnedPasswordValidatorTest extends ConstraintValidatorTestCase
 {
-    use SetUpTearDownTrait;
-
     /** @var Client|MockObject */
     private $client;
 
     /** @var P0wnedPasswordValidator */
     protected $validator;
 
-    public function doSetUp(): void
+    protected function setUp(): void
     {
         $this->client = $this->createMock(Client::class);
         parent::setUp();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes (kinda)
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

This removes support for PHP 7.1 and Symfony 3 (which is [end-of-life](https://symfony.com/releases)).
The main branch now requires PHP 7.3 and Symfony 4.4 (LTS version).


The 1.4 branch keeps compatibility with older versions and still accepts bug fixes (including new translations) but no new features. 

I was unable to fix the deprecation warnings and add support for Symfony 6 without adding a whole bunch of BC layers for no additional benefits.