### PR TITLE
Adding named arguments for constraints

### DIFF
--- a/src/Validator/Constraints/Blacklist.php
+++ b/src/Validator/Constraints/Blacklist.php
@@ -27,4 +27,30 @@ class Blacklist extends Constraint
      * @var string
      */
     public $provider;
+
+    /**
+     * Blacklist constructor.
+     *
+     * @param string|null $provider
+     * @param string|null $message
+     * @param array|null  $groups
+     * @param null        $payload
+     */
+    public function __construct(
+        array $options = null,
+        string $provider = null,
+        string $message = null,
+        array $groups = null,
+        $payload = null
+    ) {
+
+        if ($message) {
+            $options['message'] = $message;
+        }
+        if ($provider) {
+            $options['provider'] = $provider;
+        }
+
+        parent::__construct($options ?? [], $groups, $payload);
+    }
 }

--- a/src/Validator/Constraints/PasswordRequirements.php
+++ b/src/Validator/Constraints/PasswordRequirements.php
@@ -32,4 +32,70 @@ class PasswordRequirements extends Constraint
     public $requireCaseDiff = false;
     public $requireNumbers = false;
     public $requireSpecialCharacter = false;
+
+    /**
+     * PasswordRequirements constructor.
+     *
+     * @param array|null  $options
+     * @param string|null $tooShortMessage
+     * @param string|null $missingLettersMessage
+     * @param string|null $requireCaseDiffMessage
+     * @param string|null $missingNumbersMessage
+     * @param string|null $missingSpecialCharacterMessage
+     * @param int|null    $minLength
+     * @param bool        $requireLetters
+     * @param bool        $requireCaseDiff
+     * @param bool        $requireNumbers
+     * @param bool        $requireSpecialCharacter
+     * @param array|null  $groups
+     * @param null        $payload
+     */
+    public function __construct(
+        array $options = null,
+        string $tooShortMessage = null,
+        string $missingLettersMessage = null,
+        string $requireCaseDiffMessage = null,
+        string $missingNumbersMessage = null,
+        string $missingSpecialCharacterMessage = null,
+        int $minLength = null,
+        bool $requireLetters = null,
+        bool $requireCaseDiff = null,
+        bool $requireNumbers = null,
+        bool $requireSpecialCharacter = null,
+        array $groups = null,
+        $payload = null
+    ) {
+        if ($tooShortMessage) {
+            $options['tooShortMessage'] = $tooShortMessage;
+        }
+        if ($missingLettersMessage) {
+            $options['missingLettersMessage'] = $missingLettersMessage;
+        }
+        if ($requireCaseDiffMessage) {
+            $options['requireCaseDiffMessage'] = $requireCaseDiffMessage;
+        }
+        if ($missingNumbersMessage) {
+            $options['missingNumbersMessage'] = $missingNumbersMessage;
+        }
+        if ($missingSpecialCharacterMessage) {
+            $options['missingSpecialCharacterMessage'] = $missingSpecialCharacterMessage;
+        }
+        if ($minLength) {
+            $options['minLength'] = $minLength;
+        }
+        if ($requireLetters) {
+            $options['requireLetters'] = $requireLetters;
+        }
+        if ($requireCaseDiff) {
+            $options['requireCaseDiff'] = $requireCaseDiff;
+        }
+        if ($requireNumbers) {
+            $options['requireNumbers'] = $requireNumbers;
+        }
+        if ($requireSpecialCharacter) {
+            $options['requireSpecialCharacter'] = $requireSpecialCharacter;
+        }
+
+        parent::__construct($options ?? [], $groups, $payload);
+    }
 }

--- a/src/Validator/Constraints/PasswordStrength.php
+++ b/src/Validator/Constraints/PasswordStrength.php
@@ -28,6 +28,47 @@ class PasswordStrength extends Constraint
     public $unicodeEquality = false;
 
     /**
+     * PasswordStrength constructor.
+     *
+     * @param array|null  $options
+     * @param string|null $tooShortMessage
+     * @param string|null $message
+     * @param int|null    $minLength
+     * @param null        $minStrength
+     * @param bool        $unicodeEquality
+     * @param array|null  $groups
+     * @param null        $payload
+     */
+    public function __construct(
+        array $options = null,
+        string $tooShortMessage = null,
+        string $message = null,
+        int $minLength = null,
+        $minStrength = null,
+        bool $unicodeEquality = null,
+        array $groups = null,
+        $payload = null
+    ) {
+        if ($tooShortMessage) {
+            $options['tooShortMessage'] = $tooShortMessage;
+        }
+        if ($message) {
+            $options['message'] = $message;
+        }
+        if ($minLength) {
+            $options['minLength'] = $minLength;
+        }
+        if ($minStrength) {
+            $options['minStrength'] = $minStrength;
+        }
+        if ($unicodeEquality) {
+            $options['unicodeEquality'] = $unicodeEquality;
+        }
+
+        parent::__construct($options ?? [], $groups, $payload);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getDefaultOption()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    |no
| Deprecations? |no
| Fixed tickets | Fix #49 
| License       | MIT


When converting from Annotations to Attributes you should go from:

@RollerworksPassword\PasswordStrength(minLength=8, minStrength=5)

to

#[RollerworksPassword\PasswordStrength(minLength: 8, minStrength: 5)]

This is not possible at the moment because of a missing constructor