### PR TITLE
allow symfony/deprecation-contracts v3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=7.3",
         "psr/container": "^1.0 || ^2.0",
-        "symfony/deprecation-contracts": "^2.4",
+        "symfony/deprecation-contracts": "^2.4 || ^3.0",
         "symfony/polyfill-mbstring": "^1.5.0",
         "symfony/translation": "^4.4 || ^5.0 || ^6.0",
         "symfony/validator": "^4.4 || ^5.0 || ^6.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Recently there were new release of symfony/deprecation-contracts for PHP8+. Without allowing it  PasswordStrengthValidator
 on PHP8 enabled project is downgraded to v1.3.