### PR TITLE
Correct Czech translation

### DIFF
--- a/src/Resources/translations/validators.cs.xlf
+++ b/src/Resources/translations/validators.cs.xlf
@@ -78,7 +78,7 @@
             <!-- P0wnedPassword -->
             <trans-unit id="18">
                 <source>This password was found in a database of compromised passwords. It has been used {{ used }} times. For security purposes you must use something else.</source>
-                <target>Toto heslo bylo nalezeno v databázi ohrožených hesel. Byl používán {{used}} časy. Z bezpečnostních důvodů musíte použít něco jiného.    </target>
+                <target>Toto heslo bylo nalezeno v databázi ohrožených hesel. Bylo použito {{used}} krát. Z bezpečnostních důvodů musíte použít jiné heslo.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  1.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | possibly?
| Deprecations? | no
| Fixed tickets | none
| License       | MIT

Fixes Czech translation for the error message of `P0wnedPassword` component.