### PR TITLE
Fixed deprecated messages for PHP8.4+

### DIFF
--- a/src/Validator/Constraints/PasswordRequirements.php
+++ b/src/Validator/Constraints/PasswordRequirements.php
@@ -35,18 +35,18 @@ class PasswordRequirements extends Constraint
 
     public function __construct(
         mixed $options = null,
-        array $groups = null,
+        ?array $groups = null,
         mixed $payload = null,
-        int $minLength = null,
-        bool $requireLetters = null,
-        bool $requireCaseDiff = null,
-        bool $requireNumbers = null,
-        bool $requireSpecialCharacter = null,
-        string $tooShortMessage = null,
-        string $missingLettersMessage = null,
-        string $requireCaseDiffMessage = null,
-        string $missingNumbersMessage = null,
-        string $missingSpecialCharacterMessage = null
+        ?int $minLength = null,
+        ?bool $requireLetters = null,
+        ?bool $requireCaseDiff = null,
+        ?bool $requireNumbers = null,
+        ?bool $requireSpecialCharacter = null,
+        ?string $tooShortMessage = null,
+        ?string $missingLettersMessage = null,
+        ?string $requireCaseDiffMessage = null,
+        ?string $missingNumbersMessage = null,
+        ?string $missingSpecialCharacterMessage = null
     ) {
         parent::__construct($options ?? [], $groups, $payload);
 

--- a/src/Validator/Constraints/PasswordStrength.php
+++ b/src/Validator/Constraints/PasswordStrength.php
@@ -29,13 +29,13 @@ class PasswordStrength extends Constraint
 
     public function __construct(
         mixed $options = null,
-        array $groups = null,
+        ?array $groups = null,
         mixed $payload = null,
-        int $minStrength = null,
-        int $minLength = null,
-        bool $unicodeEquality = null,
-        string $message = null,
-        string $tooShortMessage = null
+        ?int $minStrength = null,
+        ?int $minLength = null,
+        ?bool $unicodeEquality = null,
+        ?string $message = null,
+        ?string $tooShortMessage = null
     ) {
         $finalOptions = [];
 


### PR DESCRIPTION
"Implicitly marking parameter $variable_name as nullable is deprecated" fixed

| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | Not exists
| License       | MIT

Just fixes a lot of deprecation warnings for PHP version 8.4+