### PR TITLE
Fixed deprecated message for PHP8.4+

### DIFF
--- a/src/Validator/Constraints/PasswordStrengthValidator.php
+++ b/src/Validator/Constraints/PasswordStrengthValidator.php
@@ -50,7 +50,7 @@ class PasswordStrengthValidator extends ConstraintValidator
         5 => 'very_strong',
     ];
 
-    public function __construct(TranslatorInterface $translator = null)
+    public function __construct(?TranslatorInterface $translator = null)
     {
         // If translator is missing create a new translator.
         // With the 'en' locale and 'validators' domain.


### PR DESCRIPTION
"Implicitly marking parameter $translator as nullable is deprecated" fixed

| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | none
| License       | MIT

Found a strangler deprecation issue.

You might want to update the phpstan/phpunit packages to the latest version, [which will "unshut" phpstan again](https://github.com/rollerworks/PasswordStrengthValidator/blob/v2.0.2/tests/Validator/PasswordRequirementsValidatorTest.php#L73) :smile: You can fix this with "?->" on the `$constraintViolationAssertion` usages, but need to retest the whole thing throughout your BC list.

Thx alot for the package!!